### PR TITLE
squash some compiler warnings, just in case

### DIFF
--- a/src/depixelize/spline_optimizer.cpp
+++ b/src/depixelize/spline_optimizer.cpp
@@ -325,7 +325,7 @@ bool SplineOptimizer::should_optimize(EdgeRef e1, EdgeRef e2,
         return false;
     }
 
-    EdgeRef last_edge;
+    EdgeRef last_edge = { 0, 0, false };
     auto range = adjacent_edges.equal_range(common_pt);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second != e1 && it->second != e2) {

--- a/src/depixelize/spline_optimizer.cpp
+++ b/src/depixelize/spline_optimizer.cpp
@@ -325,6 +325,8 @@ bool SplineOptimizer::should_optimize(EdgeRef e1, EdgeRef e2,
         return false;
     }
 
+    // `last_edge` is guaranteed to be assigned in this loop; initialization
+    // is just to silence a compiler warning
     EdgeRef last_edge = { 0, 0, false };
     auto range = adjacent_edges.equal_range(common_pt);
     for (auto it = range.first; it != range.second; ++it) {

--- a/src/geometry/bspline.hpp
+++ b/src/geometry/bspline.hpp
@@ -124,9 +124,6 @@ public:
 
         double num = d1.x * d2.y - d1.y * d2.x;
         double den = pow(d1.x * d1.x + d1.y * d1.y, 3 / 2.0);
-        if (den == 0) {
-            return 0;
-        }
 
         for (auto &p : deriv1.points) {
             delete p;
@@ -134,7 +131,11 @@ public:
         for (auto &p : deriv2.points) {
             delete p;
         }
-        return fabs(num / den);
+
+        double q = num / den;
+        return (std::isinf(q) || std::isnan(q))
+            ? 0
+            : fabs(q);
     }
 
     double integrate_span(std::function<double(double)> f, const Point &span) const

--- a/src/geometry/point.hpp
+++ b/src/geometry/point.hpp
@@ -1,6 +1,9 @@
 #ifndef DEPIXELIZE_POINT_HPP
 #define DEPIXELIZE_POINT_HPP
 
+#include <cmath>
+#include <limits>
+
 #include <boost/polygon/voronoi.hpp>
 
 #include "geometry/types.hpp"
@@ -16,12 +19,18 @@ public:
     virtual ~Point() { }
     bool operator==(const Point &other) const
     {
-        return this->x == other.x && this->y == other.y;
+        return
+          fabs(this->x - other.x) < std::numeric_limits<double>::epsilon() &&
+          fabs(this->y - other.y) < std::numeric_limits<double>::epsilon();
     }
 
     bool operator<(const Point &other) const
     {
-        return this->x < other.x || (this->x == other.x && this->y < other.y);
+        return
+          this->x < other.x || (
+            fabs(this->x - other.x) < std::numeric_limits<double>::epsilon() &&
+            this->y < other.y
+          );
     }
 
     Point operator+(const Point &other) const


### PR DESCRIPTION
In `spline_optimizer.cpp`, I think I'm just silencing a warning that had no practical negative consequence. But the code looked a little alarming, because there was no confirmation that the thing being searched for was actually found.

In `bspline.hpp`, I got rid of a worrisome floating point comparison. I think it may also fix a memory leak. Please double-check.
